### PR TITLE
fix: change parse of responses in the rest.py

### DIFF
--- a/rest.py
+++ b/rest.py
@@ -262,14 +262,16 @@ class RestClient(object):  # noqa pylint: disable=R0205
         """
         if not response.text:
             return EmptyResponse(response.status_code)
-        if response.headers['Content-Type'] == 'application/octet-stream':
-            return RawResponse(response)
         try:
-            return JsonResponse(response)
+            if response.headers['Content-Type'] == 'application/octet-stream':
+                return RawResponse(response)
+            if response.headers['Content-Type'].startswith('application/json'):
+                return JsonResponse(response)
+            return PlainResponse(response)
         except ValueError:
             logger.error('Unable to parse response as JSON',
                          exc_info=EXEC_INFO)
-            return PlainResponse(response)
+            return ""
 
 
 class Response(object):  # noqa pylint: disable=R0205,R0903


### PR DESCRIPTION
It is more conservative about parsing as JSON.
Aims to fix #44 .

Unfortunately I could not test this because I am blocked by #40
