### PR TITLE
fix: correct warning for proxy limit - it's no longer 60

### DIFF
--- a/qualification_report_mapping_json/proxies_per_env.json
+++ b/qualification_report_mapping_json/proxies_per_env.json
@@ -1,14 +1,22 @@
 {
-    "headers": ["Organization", "Environment", "Proxies", "SharedFlows", "Proxies Shared Flows"],
-    "info_block": {
-        "text": "<b>[Feature Parity] Max Proxies + SharedFlows per Environment\n\nApigee X has a limit of 60 Proxies + SharedFlow (with maximum of 50 for deployed proxies) per environment.\n\n<iu>Workaround:\nDepending on your implementation, sharding the proxies and sharedflows to multiple environments to make the limit could be a workaround. Please be aware of environment-level properties before doing this (i.e. cache)\n\n<iu>Long Term Plan:\nApigee Engineering is working on a fix that eliminate the limit on environment-level but will retain the limit on the org-level. SharedFlow has been updated to 75 per env.",
-        "text_line_no_for_col_count": 2,
-        "col_merge": 3,
-        "start_row": 2,
-        "end_row": 14,
-        "link":[{
-            "link_text": "Proxies and Sharedflow limits",
-            "link": "https://cloud.google.com/apigee/docs/api-platform/reference/limits#api-proxies"
-        }]
-    }
+  "headers": [
+    "Organization",
+    "Environment",
+    "Proxies",
+    "SharedFlows",
+    "Proxies Shared Flows"
+  ],
+  "info_block": {
+    "text": "<b>[Feature Parity] Max Proxies + SharedFlows per Environment\n\nUnder the Subscription 2021 plan, Apigee X has a limit of 60 Proxies + SharedFlow (with maximum of 50 for deployed proxies) per environment.\n\n<iu>Workaround:\nEnsure you are entitled to Apigee X via a Subscription 2024 contract. Or, Depending on your implementation, sharding the proxies and sharedflows to multiple environments to make the limit could be a workaround. Please be aware of environment-level properties before doing this (i.e. cache)\n",
+    "text_line_no_for_col_count": 2,
+    "col_merge": 3,
+    "start_row": 2,
+    "end_row": 14,
+    "link": [
+      {
+        "link_text": "Proxies and Sharedflow limits",
+        "link": "https://cloud.google.com/apigee/docs/api-platform/reference/limits#api-proxies"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Fixes #29

- [ ] Tests pass - I did not run tests , blocked due to #40 
- [ ] Appropriate changes to README are included in PR.  No change to README on this.